### PR TITLE
Make creamcloud-backup Keystone V3 compatible

### DIFF
--- a/creamcloud-backup/common.sh
+++ b/creamcloud-backup/common.sh
@@ -131,7 +131,6 @@ remove_symlink() {
 
 get_hostname() {
     HOSTNAME="$(curl -m 3 -s http://169.254.169.254/openstack/latest/meta_data.json | grep -o '\"hostname\": \"[^\"]*\"' | awk -F\" '{print $4}')"
-    SRV_IP_ADDR="$(curl -q -A CloudVPS-Boss -m 3 -o /dev/null -s https://raymii.org/ >/dev/null 2>/dev/null)"
     if [[ -z "${HOSTNAME}" ]]; then
         if [[ -f "/var/firstboot/settings" ]]; then
             HOSTNAME="$(awk -F= '/hostname/ {print $2}' /var/firstboot/settings)"
@@ -139,7 +138,7 @@ get_hostname() {
             HOSTNAME="$(uname -n)"
         fi
     fi
-    echo "${HOSTNAME}"
+    echo "Retrieved hostname: ${HOSTNAME}"
 }
 
 ctrl_c() {

--- a/credentials.sh
+++ b/credentials.sh
@@ -67,22 +67,22 @@ if [[ "${1}" == "help" ]]; then
 elif [[ -z ${2} || -z ${1} || -z ${3} ]]; then
     echo; echo; echo; echo; echo;
     read -e -p "Openstack Username (user@example.org): " USERNAME
-    read -e -s -p "Openstack Password (not shown):" PASSWORD
+    read -e -s -p "Openstack Password (not shown): " PASSWORD
     echo
-    read -e -p "Openstack Project ID: " TENANT_ID
+    read -e -p "Openstack Project ID: " PROJECT_ID
     read -e -p "OpenStack User Domain Name: " OS_USER_DOMAIN_NAME
     read -e -p "OpenStack Project Domain Name: " OS_PROJECT_DOMAIN_NAME
     read -e -p "Openstack Region: " OS_REGION
 else
     USERNAME="${1}"
     PASSWORD="${2}"
-    TENANT_ID="${3}"
+    PROJECT_ID="${3}"
     OS_REGION="${4}"
     OS_USER_DOMAIN_NAME="${5}"
     OS_PROJECT_DOMAIN_NAME="${6}"
 fi
 
-if [[ -z "${USERNAME}" || -z "${PASSWORD}" || -z "${TENANT_ID}" || -z "${OS_REGION}" || -z "${OS_USER_DOMAIN_NAME}" || -z "${OS_PROJECT_DOMAIN_NAME}" ]]; then
+if [[ -z "${USERNAME}" || -z "${PASSWORD}" || -z "${PROJECT_ID}" || -z "${OS_REGION}" || -z "${OS_USER_DOMAIN_NAME}" || -z "${OS_PROJECT_DOMAIN_NAME}" ]]; then
     echo
     lerror "Need username, password, project id, region and domain names."
     exit 1
@@ -100,13 +100,13 @@ if [[ $? -ne 0 ]]; then
         lerror "Please install curl or wget"
         exit 1
     else
-        AUTH_TOKEN=$(wget -q --header="Content-Type: application/json" --header "Accept: application/json" -O - --post-data='{"auth": {"identity": {"methods": ["password"],"region": "'${OS_REGION}'","password": {"user": {"name": "'${USERNAME}'","domain": { "name": "'${OS_USER_DOMAIN_NAME}'" },"password": "'${PASSWORD}'"}}},"scope": {"project": {"id": "'${TENANT_ID}'"}}}}' "${OS_AUTH_URL}" | grep -o '\"id\": \"[^\"]*\"' | awk -F\" '{print $4}' | sed -n 1p)
+        AUTH_TOKEN=$(wget -q --header="Content-Type: application/json" --header "Accept: application/json" -O - --post-data='{"auth": {"identity": {"methods": ["password"],"region": "'${OS_REGION}'","password": {"user": {"name": "'${USERNAME}'","domain": { "name": "'${OS_USER_DOMAIN_NAME}'" },"password": "'${PASSWORD}'"}}},"scope": {"project": {"id": "'${PROJECT_ID}'"}}}}' "${OS_AUTH_URL}" | grep -o '\"id\": \"[^\"]*\"' | awk -F\" '{print $4}' | sed -n 1p)
     fi
 else
-    AUTH_TOKEN=$(curl -s "${OS_AUTH_URL}" -X POST -H "Content-Type: application/json" -H "Accept: application/json"  -d '{"auth": {"identity": {"methods": ["password"],"region": "'${OS_REGION}'","password": {"user": {"name": "'${USERNAME}'","domain": { "name": "'${OS_USER_DOMAIN_NAME}'" },"password": "'${PASSWORD}'"}}},"scope": {"project": {"id": "'${TENANT_ID}'"}}}}' | grep -o '\"id\": \"[^\"]*\"' | awk -F\" '{print $4}' | sed -n 1p)
+    AUTH_TOKEN=$(curl -s "${OS_AUTH_URL}" -X POST -H "Content-Type: application/json" -H "Accept: application/json"  -d '{"auth": {"identity": {"methods": ["password"],"region": "'${OS_REGION}'","password": {"user": {"name": "'${USERNAME}'","domain": { "name": "'${OS_USER_DOMAIN_NAME}'" },"password": "'${PASSWORD}'"}}},"scope": {"project": {"id": "'${PROJECT_ID}'"}}}}' | grep -o '\"id\": \"[^\"]*\"' | awk -F\" '{print $4}' | sed -n 1p)
 fi
 
-if [[ -z "${TENANT_ID}" ]]; then
+if [[ -z "${PROJECT_ID}" ]]; then
     lerror "Project ID could not be found. Check username, password or network connectivity."
     exit 1
 fi
@@ -122,10 +122,10 @@ if [[ -z "${AUTH_TOKEN}" ]]; then
             lerror "Please install curl or wget"
             exit 1
         else
-            AUTH_TOKEN=$(wget -q --header="Content-Type: application/json" --header "Accept: application/json" -O - --post-data='{"auth": {"identity": {"methods": ["password"],"region": "'${OS_REGION}'","password": {"user": {"name": "'${USERNAME}'","domain": { "name": "'${OS_USER_DOMAIN_NAME}'" },"password": "'${PASSWORD}'"}}},"scope": {"project": {"id": "'${TENANT_ID}'"}}}}' "${OS_AUTH_URL}" | grep -o '\"id\": \"[^\"]*\"' | awk -F\" '{print $4}' | sed -n 1p)
+            AUTH_TOKEN=$(wget -q --header="Content-Type: application/json" --header "Accept: application/json" -O - --post-data='{"auth": {"identity": {"methods": ["password"],"region": "'${OS_REGION}'","password": {"user": {"name": "'${USERNAME}'","domain": { "name": "'${OS_USER_DOMAIN_NAME}'" },"password": "'${PASSWORD}'"}}},"scope": {"project": {"id": "'${PROJECT_ID}'"}}}}' "${OS_AUTH_URL}" | grep -o '\"id\": \"[^\"]*\"' | awk -F\" '{print $4}' | sed -n 1p)
         fi
     else
-        AUTH_TOKEN=$(curl -s "${OS_AUTH_URL}" -X POST -H "Content-Type: application/json" -H "Accept: application/json"  -d '{"auth": {"identity": {"methods": ["password"],"region": "'${OS_REGION}'","password": {"user": {"name": "'${USERNAME}'","domain": { "name": "'${OS_USER_DOMAIN_NAME}'" },"password": "'${PASSWORD}'"}}},"scope": {"project": {"id": "'${TENANT_ID}'"}}}}' | grep -o '\"id\": \"[^\"]*\"' | awk -F\" '{print $4}' | sed -n 1p)
+        AUTH_TOKEN=$(curl -s "${OS_AUTH_URL}" -X POST -H "Content-Type: application/json" -H "Accept: application/json"  -d '{"auth": {"identity": {"methods": ["password"],"region": "'${OS_REGION}'","password": {"user": {"name": "'${USERNAME}'","domain": { "name": "'${OS_USER_DOMAIN_NAME}'" },"password": "'${PASSWORD}'"}}},"scope": {"project": {"id": "'${PROJECT_ID}'"}}}}' | grep -o '\"id\": \"[^\"]*\"' | awk -F\" '{print $4}' | sed -n 1p)
     fi
     if [[ -z "${AUTH_TOKEN}" ]]; then
         lerror "AUTH_TOKEN could not be found after two tries. Check username, password or network connectivity."
@@ -139,7 +139,7 @@ if [[ ! -f "/etc/creamcloud-backup/auth.conf" ]]; then
     cat << EOF > /etc/creamcloud-backup/auth.conf
 export OS_USERNAME="${USERNAME}"
 export OS_PASSWORD="${PASSWORD}"
-export OS_PROJECT_ID="${TENANT_ID}"
+export OS_PROJECT_ID="${PROJECT_ID}"
 export OS_USER_DOMAIN_NAME="${OS_USER_DOMAIN_NAME}"
 export OS_PROJECT_DOMAIN_NAME="${OS_PROJECT_DOMAIN_NAME}"
 export OS_REGION_NAME=${OS_REGION}
@@ -153,9 +153,9 @@ fi
 
 lecho "Username: ${USERNAME}"
 lecho "Auth URL: ${OS_BASE_AUTH_URL}"
-lecho "Checking Swift Container for Backups: https://public.objectstore.eu/v1/${TENANT_ID}/creamcloud-backup/"
+lecho "Checking Swift Container for Backups: https://public.objectstore.eu/v1/${PROJECT_ID}/creamcloud-backup/"
 
-curl -s -o /dev/null -X PUT -T "/etc/hosts" --user "${USERNAME}:${PASSWORD}" "https://public.objectstore.eu/v1/${TENANT_ID}/creamcloud-backup/"
+curl -s -o /dev/null -X PUT -T "/etc/hosts" --user "${USERNAME}:${PASSWORD}" "https://public.objectstore.eu/v1/${PROJECT_ID}/creamcloud-backup/"
 if [[ $? == 60 ]]; then
     # CentOS 5...
     lecho "Curl error Peer certificate cannot be authenticated with known CA certificates."

--- a/credentials.sh
+++ b/credentials.sh
@@ -90,7 +90,6 @@ fi
 
 OS_BASE_AUTH_URL="https://auth.teamblue.cloud/v3"
 OS_AUTH_URL="${OS_BASE_AUTH_URL}/auth/tokens"
-OS_TENANTS_URL="${OS_BASE_AUTH_URL}/auth/projects"
 
 command -v curl > /dev/null 2>&1
 if [[ $? -ne 0 ]]; then

--- a/install.sh
+++ b/install.sh
@@ -53,7 +53,7 @@ usage() {
     echo "To install Cream Cloud Backup with interactive username password question:"
     echo "./$0"
     echo; echo "To install Cream Cloud Backup non-interactive:"
-    echo "./$0 username@domain.tld 'passw0rd' 'tenant id'"
+    echo "./$0 username@domain.tld 'passw0rd' 'project id' 'region' 'user domain name' 'project domain name'"
 }
 
 if [[ ! -z "$1" ]]; then
@@ -172,6 +172,8 @@ case "${DISTRO_NAME}" in
 
     *)
     lerror "Distro unknown or not supported"
+    lerror "Please install the required packages manually. (awk sed grep tar gzip which openssl curl wget screen vim haveged restic)"
+    lerror "Instructions on installing restic can be found at https://restic.readthedocs.io/en/stable/020_installation.html"
     exit 1
     ;;
 esac

--- a/install.sh
+++ b/install.sh
@@ -138,7 +138,7 @@ install_packages_debian() {
         lerror "'apt-get update' failed."
         exit 1
     fi
-    for PACKAGE in awk sed grep tar gzip which openssl curl wget screen vim haveged unattended-upgrades; do
+    for PACKAGE in jq awk sed grep tar gzip which openssl curl wget screen vim haveged unattended-upgrades; do
         /usr/bin/apt-get -qq -y --force-yes -o "Dpkg::Options::=--force-confdef" -o "Dpkg::Options::=--force-confold" install "${PACKAGE}" >/dev/null 2>&1
     done
 }
@@ -148,7 +148,7 @@ install_packages_centos() {
 
     yum-config-manager --add-repo https://copr.fedorainfracloud.org/coprs/copart/restic/repo/epel-7/copart-restic-epel-7.repo
 
-    for PACKAGE in awk sed grep tar gzip which openssl curl wget screen vim haveged yum-cron restic; do
+    for PACKAGE in jq awk sed grep tar gzip which openssl curl wget screen vim haveged yum-cron restic; do
         yum -q -y --disablerepo="*" --disableexcludes=main --enablerepo="base" --enablerepo="updates" --enablerepo="copr:copr.fedorainfracloud.org:copart:restic" install "${PACKAGE}" >/dev/null 2>&1
     done
 }
@@ -172,7 +172,7 @@ case "${DISTRO_NAME}" in
 
     *)
     lerror "Distro unknown or not supported"
-    lerror "Please install the required packages manually. (awk sed grep tar gzip which openssl curl wget screen vim haveged restic)"
+    lerror "Please install the required packages manually. (jq awk sed grep tar gzip which openssl curl wget screen vim haveged restic)"
     lerror "Instructions on installing restic can be found at https://restic.readthedocs.io/en/stable/020_installation.html"
     exit 1
     ;;


### PR DESCRIPTION
## Summary
This PR updates the creamcloud-backup script to ensure compatibility with the Keystone V3 API, as implemented at the TransIP Objectstore. More details about the Keystone V3 API can be found [here](https://docs.openstack.org/api-ref/identity/v3/).

## Noteworthy Changes

### Changes:
- **`credentials.sh`**  
  - Added prompts for **domain name** and **region name**, both required for V3 authentication.  
  - Updated authentication process to retrieve `project_name` (required by Restic for Keystone API authentication) instead of only checking for an ID in the authentication output.  

- **`common.sh`**  
  - Removed the unused `curl` call to `raymii.org`.  

- **`install.sh`**  
  - Updated to include the correct **ObjectStore IPs** and removed outdated, unused IPs.  
  - Added `jq` to the required packages list, as it is now used in `credentials.sh` to extract the `project_name` from the authentication token response body.
